### PR TITLE
Update Slice implementation

### DIFF
--- a/include/lib.h
+++ b/include/lib.h
@@ -331,6 +331,33 @@ struct Slice
   {
   }
 
+  template<typename S, typename V, typename... MTs>
+  struct FindIndex
+  {
+  };
+
+  template<typename S, typename... ETs, typename... MTs>
+  struct FindIndex<S, std::tuple<ETs...>, MTs...>
+  {
+    constexpr static std::size_t value =
+        FindElement<S, typename std::remove_reference_t<ETs>::MarkerTypes...>::
+            value;
+  };
+
+  template<typename... MTs>
+  auto& Get()
+  {
+    std::ignore = CheckMarkerTypesForUniqueness<MTs...> {};
+    using SType = typename MergeMarkers<MTs...>::MarkerTypes;
+    return std::get<FindIndex<SType, DType, MTs...>::value>(this->data);
+  }
+
+  template<typename... MTs>
+  auto ShrinkTo()
+  {
+    return Slice<DType, MTs...>::Create(this->data);
+  }
+
   DType data;
 };
 

--- a/include/test.cpp
+++ b/include/test.cpp
@@ -149,14 +149,14 @@ using DD =
 template<typename T>
 void TestCoercionInt(Slice<typename T::DType, int> s)
 {
-  EXPECT_EQ(std::get<0>(s.data).data, 13);
-  EXPECT_EQ(std::get<1>(s.data).data, 7);
+  EXPECT_EQ(s.template Get<MG>().data, 7);
+  EXPECT_EQ(s.template Get<int>().data, 13);
 }
 
 template<typename T>
 void TestCoercionChar(Slice<typename T::DType, char> s)
 {
-  EXPECT_EQ(std::get<0>(s.data).data, 7);
+  EXPECT_EQ(s.template Get<MG>().data, 7);
 }
 
 TEST(Slice, ImplicitCoercionSliceTest)
@@ -169,8 +169,10 @@ TEST(Slice, ImplicitCoercionSliceTest)
   TestCoercionInt<DD>(disp);
 
   auto t = disp.ShrinkTo<int>();
-
   TestCoercionChar<decltype(t)>(t);
+
+  auto s = t.ShrinkTo<char>();
+  TestCoercionChar<decltype(s)>(s);
 }
 
 }  // namespace


### PR DESCRIPTION
Get function is implemented for Slice structure to query slice data with marker types
ShrinkTo function is implemented to create a slice from Slice object